### PR TITLE
Fix single spymaster check.

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,8 +412,15 @@ function switchRole(socket, data){
     return
   }
 
-  if (room.players.some(player => player.team === currentPlayer.team && player.role === 'spymaster')) {
+  var teamHasSpymaster = false
+  for (let player in ROOM_LIST[room].players){
+    if (PLAYER_LIST[player].team === currentPlayer.team && PLAYER_LIST[player].role === 'spymaster'){
+      teamHasSpymaster = true
+    }
+  }
+  if (teamHasSpymaster){
     socket.emit('switchRoleResponse', {success:false})
+    return
   }
 
   currentPlayer.role = data.role; // Set the new role

--- a/app.js
+++ b/app.js
@@ -412,16 +412,15 @@ function switchRole(socket, data){
     return
   }
 
-  var teamHasSpymaster = false
-  for (let player in ROOM_LIST[room].players){
-    if (PLAYER_LIST[player].team === currentPlayer.team && PLAYER_LIST[player].role === 'spymaster'){
-      teamHasSpymaster = true
-      break
+  // Do not allow to switch to spymaster if there is already one in the team
+  if (data.role === 'spymaster') {
+    for (let player in ROOM_LIST[room].players) {
+      const otherPlayer = PLAYER_LIST[player];
+      if (otherPlayer !== currentPlayer && otherPlayer.team === currentPlayer.team && otherPlayer.role === 'spymaster') {
+        socket.emit('switchRoleResponse', {success:false})
+        return
+      }
     }
-  }
-  if (teamHasSpymaster){
-    socket.emit('switchRoleResponse', {success:false})
-    return
   }
 
   currentPlayer.role = data.role; // Set the new role

--- a/app.js
+++ b/app.js
@@ -416,6 +416,7 @@ function switchRole(socket, data){
   for (let player in ROOM_LIST[room].players){
     if (PLAYER_LIST[player].team === currentPlayer.team && PLAYER_LIST[player].role === 'spymaster'){
       teamHasSpymaster = true
+      break
     }
   }
   if (teamHasSpymaster){


### PR DESCRIPTION
The original logic doesn't work because
1. `room.players` is a collection of socket IDs, not `Player` objects, so the `PLAYER_LIST` object has to be used to get access to the `Player` objects.
2. `room.players` is a plain object, not an array, so `Array.some` is not available. In order to avoid changing other parts of the code, I just re-wrote it to use a `for in` loop instead.

I have tested this code locally to confirm to behaves as expected.